### PR TITLE
fixed to make TestHarness full runnable (on my machine)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__
 *.egg-info
 logs/
 Translator-Tests/
+build/
+test_ars.log
 
 # PyCharms IDE metadata to be ignored
 .idea/

--- a/README.md
+++ b/README.md
@@ -21,5 +21,8 @@ The Test Harness is a CLI that you need to install:
 - `pip install -r requirements-runners.txt` to install the Test Runners
 - `pip install .` to install the Test Harness CLI
 
+Create a local 'logs' directory (the repository doesn't track or commit this...):
+- `mkdir logs`
+
 Once everything is installed, you can call
 - `test-harness -h` to see available options

--- a/requirements-runners.txt
+++ b/requirements-runners.txt
@@ -1,2 +1,6 @@
 ARS_Test_Runner==0.0.2
 ui-test-runner==0.0.1
+
+# Dependency for the ui-test-runner
+# not automatically pulled in
+jq==1.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 httpx==0.25.0
 pydantic==1.10.13
+tqdm==4.66.1


### PR DESCRIPTION
To allow execution, added some missing pip dependencies plus README instruction to (re-)create the root folder **`logs`** folder (not tracked by repo)