### PR TITLE
Don't use the normalized input category

### DIFF
--- a/test_harness/run.py
+++ b/test_harness/run.py
@@ -75,9 +75,11 @@ async def run_tests(
             normalized_curies = await normalize_curies(test, logger)
             input_curie = normalized_curies[test.test_case_input_id]["id"]["identifier"]
             # try and get normalized input category, but default to original
-            input_category = normalized_curies[test.test_case_input_id].get(
-                "type", [test.input_category]
-            )[0]
+            # input_category = normalized_curies[test.test_case_input_id].get(
+            #     "type", [test.input_category]
+            # )[0]
+            # TODO: figure out the right way to handle input category wrt normalization
+            input_category = test.input_category
 
             err_msg = ""
             for asset in assets:


### PR DESCRIPTION
The ARS Test Runner requires specific input curie categories. With normalization in place, we were getting back some that were changed from `Biolink:ChemicalEntity` to `Biolink:SmallMolecule` and that was causing the test runner to error. More thought probably needs to be put into this, but for right now, this just reverts things back to use the input category directly from the test case.